### PR TITLE
index.html: fix bad href

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,7 +30,7 @@
 <p>On the network, an <span class="nowrap">I2P<span class="super">+</span></span> router will identify as a normal I2P router.</p>
 <h3><span class="nowrap">I2P<span class="super">+</span></span> Screenshots</h3>
 <div id="screenshots">
-<a href="resources/images/theme_override.png" target="_blank" title="Custom console theme override.css in action"><img src="resources/images/thumbs/theme_override.png"></a>
+<a href="resources/images/theme_override.jpg" target="_blank" title="Custom console theme override.css in action"><img src="resources/images/thumbs/theme_override.png"></a>
 <a href="resources/images/charcoal.png" target="_blank" title="'Charcoal' override.css applied to light console theme"><img src="resources/images/thumbs/charcoal.png"></a>
 <a href="resources/images/oceanblue.png" target="_blank" title="'OceanBlue' override.css applied to dark console theme"><img src="resources/images/thumbs/oceanblue.png"></a>
 <a href="resources/images/peer_failrate.png" target="_blank" title="Visual indication of fail rate of peers on profiles page"><img src="resources/images/peer_failrate.png"></a>


### PR DESCRIPTION

<img width="470" alt="Screen Shot 2021-08-28 at 8 55 57 AM" src="https://user-images.githubusercontent.com/3574444/131218618-eaea687e-60b5-4805-ad61-c16167cad34c.png">


it turns out that such file is a `jpg` rather than `png`


```
find . -name "theme_override*"
./resources/images/theme_override.jpg
./resources/images/thumbs/theme_override.jpg
./resources/images/thumbs/theme_override.png
```